### PR TITLE
Fixed misleading explanatino in document

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,10 +6,10 @@
 
 Count metricses below about matches.
 
-- Messages per min/hour/day
-- Bytes per min/hour/day
-- Messages per second (average every min/hour/day)
-- Bytes per second (average every min/hour/day)
+- Messages per minute/hour/day
+- Bytes per minute/hour/day
+- Messages per second (average every minute/hour/day)
+- Bytes per second (average every minute/hour/day)
 
 FlowCounterOutput emits messages contains results data, so you can output these message (with 'flowcount' tag by default) to any outputs you want.
 


### PR DESCRIPTION
`min` is misleading because `unit` option accept `minute`.
