### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fluent-plugin-flowcounter
+# fluent-plugin-flowcounter, a plugin for [Fluentd](http://fluentd.org)
 
 Count metricses below about matches.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
