### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# fluent-plugin-flowcounter, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-flowcounter
 
-Count metricses below about matches.
+Count metrics below about matches. This is a plugin for [Fluentd](http://fluentd.org)
 
 * Messages per second/minute/hour/day
 * Bytes per second/minute/hour/day


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
