### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_flowcounter'
 
 class Test::Unit::TestCase


### PR DESCRIPTION
I've migrated this plugin to use v0.14 API and leave gem version as-is.
Please release new version which specifies fluentd v0.12 as upper bound before merging this.
