### PR TITLE
Support stop send 0 flow counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ Use '${hostname}' if you want your hostname in tag.
       tag fluentd.node.${hostname}
     </match>
 
+Counts active tag, stop count records if the tag message stoped(when aggragates per tag).
+
+    <match target.**>
+      @type flowcounter
+      count_keys *
+      aggregate tag
+      delete_idle true
+    </match>
+
 ## TODO
 
 * consider what to do next

--- a/lib/fluent/plugin/out_flowcounter.rb
+++ b/lib/fluent/plugin/out_flowcounter.rb
@@ -20,6 +20,7 @@ class Fluent::FlowCounterOutput < Fluent::Output
   config_param :input_tag_remove_prefix, :string, default: nil
   config_param :count_keys, :string, default: nil
   config_param :delimiter, :string, default: '_'
+  config_param :delete_idle, :bool, default: false
 
   include Fluent::Mixin::ConfigPlaceholders
 
@@ -126,12 +127,14 @@ class Fluent::FlowCounterOutput < Fluent::Output
   end
 
   def flush(step)
-    flushed,@counts = @counts,count_initialized(@counts.keys)
+    keys = delete_idle ? nil : @counts.keys
+    flushed,@counts = @counts,count_initialized(keys)
     generate_output(flushed, step)
   end
 
   def tagged_flush(step)
-    flushed,@counts = @counts,count_initialized(@counts.keys)
+    keys = delete_idle ? nil : @counts.keys
+    flushed,@counts = @counts,count_initialized(keys)
     names = flushed.keys.select {|x| x.end_with?(delimiter + 'count')}.map {|x| x.chomp(delimiter + 'count')}
     names.map {|name|
       counts = {


### PR DESCRIPTION
This plugin still send `count: 0` after stop writing events: 
```
2016-10-11 06:41:01 +0000 fluentd-metrics: {"count":0,"bytes":0,"count_rate":0.0,"bytes_rate":0.0,"tag":"debug.where"}
```

so, we added a param `delete_idle`, same as `deleteIdleStats` in `statsd`:
```
  deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
                    as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
                    the previous value). Can be individually overriden. [default: false]
```

After setting `delete_idle true`, plugin send no flow counter after stop write events.