### PR TITLE
add clock output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ Counts active tag, stop count records if the tag message stoped(when aggragates 
       delete_idle true
     </match>
 
+Set `use_clock_output` to `true`(default is `false`) and set `clock_output_interval`(support `minutely`|`hourly`|`daily`, default is `minutely`) when using clock output format.
+
+    <match target.**>
+      @type flowcounter
+      count_keys *
+      aggregate tag
+      use_clock_output true
+      clock_output_interval daily
+    </match>
+
 ## TODO
 
 * consider what to do next


### PR DESCRIPTION
hi, tagomoris
we want to count records and show it at every hour or minute or day, for example, if we start at 2017-07-23 13:04:10, and if use clock output format, it will count and show at 14:00:00、15:00:00...(interval is hourly) or 13:05:00、13:06:00...(interval is minutely) or 2017-07-24 00:00:00、2017-07-25 00:00:00...(interval is daily)